### PR TITLE
Show last 10 jobs of each Task in the Tasks list view

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "bulma": "^0.7.5",
+    "bulma-tooltip": "^2.0.2",
     "core-js": "^2.6.5",
     "vue": "^2.6.10",
     "vue-router": "^3.0.3"

--- a/ui/src/components/Task.vue
+++ b/ui/src/components/Task.vue
@@ -88,7 +88,7 @@
             v-for="job of task.jobs"
             style="width: 100%">
             <div class="card job-card" align="left"
-            v-bind:style="{ 'background': jobColorByStatus(job.job_status) }">
+            v-bind:style="{ 'background': jobCardColorByStatus(job.job_status) }">
               <div class="card-content">
                 <router-link
                   :to="{path: '/tasks/' + $route.params.task_id + '/job/' + job.job_id }">
@@ -145,17 +145,9 @@ export default {
       this.jobResult = job.result;
       this.selected = 'job_details';
     },
-    jobColorByStatus(status) {
-      if (status === 'finished') {
-        return 'linear-gradient(to right,#39aa56 0,#39aa56 10px,#fff 10px,#fff 100%) no-repeat';
-      } if (status === 'failed') {
-        return 'linear-gradient(to right,red 0,red 10px,#fff 10px,#fff 100%) no-repeat';
-      } if (status === 'queued') {
-        return 'linear-gradient(to right,gray 0,gray 10px,#fff 10px,#fff 100%) no-repeat';
-      } if (status === 'started') {
-        return 'linear-gradient(to right,#ffd21f 0,#ffd21f 10px,#fff 10px,#fff 100%) no-repeat';
-      }
-      return '';
+    jobCardColorByStatus(status) {
+      const color = this.jobColorByStatus(status);
+      return `linear-gradient(to right,${color} 0,${color} 10px,#fff 10px,#fff 100%) no-repeat`;
     },
   },
   watch: {

--- a/ui/src/components/Tasks.vue
+++ b/ui/src/components/Tasks.vue
@@ -33,7 +33,18 @@
               <router-link :to="{path: '/tasks/' + task.task_id }">
                 <div class="columns">
                   <div class="column" style="margin-left: 10px; border-right: 1px solid #c2c2c2;">
-                    <p class="title is-6">{{task.task_id}}</p>
+                    <div class="title is-6">
+                      <p style="display: inline-block; float: left">
+                        {{task.task_id}}</p>
+                      <div class="job-square tooltip is-tooltip-bottom is-tooltip-multiline"
+                      align="center"
+                      v-bind:data-tooltip="job.job_id + ' - ' + job.job_status"
+                      v-bind:key="job.job_id"
+                      v-for="job of task.jobs.slice(0,10)"
+                      v-bind:style="{ 'background-color': jobColorByStatus(job.job_status),
+                                      'float': 'right' }">
+                      </div>
+                    </div>
                     <p>{{task.status}}</p>
                   </div>
                   <div class="column" style="margin-left: 10px;">
@@ -88,10 +99,28 @@ export default {
       .get('/tasks/list')
       .then((response) => {
         this.tasks = response.data;
+        this.getTasksJobs();
       })
       .catch((e) => {
         this.errors.push(e.response);
       });
+  },
+  methods: {
+    getTasksJobs() {
+      this.tasks.forEach((task) => {
+        this.getTaskJobs(task);
+      });
+    },
+    getTaskJobs(task) {
+      axios
+        .get(`/tasks/id/${task.task_id}`)
+        .then((response) => {
+          task.jobs = response.data.jobs.reverse(); // eslint-disable-line no-param-reassign
+        })
+        .catch((e) => {
+          this.errors.push(e.response);
+        });
+    },
   },
 };
 </script>
@@ -115,6 +144,12 @@ article {
   margin-top: 20px;
   margin-left: auto;
   margin-right: auto;
+}
+.job-square {
+  width: 20px;
+  height: 20px;
+  margin-left: 3px;
+  display: inline-block;
 }
 .task-card a {
   color: #4a4a4a !important;

--- a/ui/src/components/mixins/cssTask.js
+++ b/ui/src/components/mixins/cssTask.js
@@ -22,6 +22,18 @@ const cssTask = {
       }
       return '';
     },
+    jobColorByStatus(status) {
+      if (status === 'finished') {
+        return '#39aa56';
+      } if (status === 'failed') {
+        return 'red';
+      } if (status === 'queued') {
+        return 'gray';
+      } if (status === 'started') {
+        return '#ffd21f';
+      }
+      return '';
+    },
   },
 };
 

--- a/ui/src/sass/style.scss
+++ b/ui/src/sass/style.scss
@@ -5,3 +5,4 @@ $link: #d17d00;
 
 
 @import "../../node_modules/bulma/bulma.sass";
+@import '../../node_modules/bulma-tooltip/dist/css/bulma-tooltip.sass';


### PR DESCRIPTION
In order to have an overview of the last executed jobs of a Task,
this PR adds 10 colored squares on the Tasks view (on the
right of each Task card) that show the status of the last 10 jobs
of the Task.

Moreover, there is a tooltip on each square that shows the ID of
the job and the status written.
