### PR TITLE
Show job logs

### DIFF
--- a/raistlin/tasks/urls.py
+++ b/raistlin/tasks/urls.py
@@ -9,5 +9,7 @@ urlpatterns = [
     url(r'^list', views.TasksList.as_view(), name='tasks list'),
     url(r'^id/(?P<task_id>[a-zA-Z0-9_.-]+)/$', views.Task.as_view(),
         name='task by id'),
+    url(r'^job_id/(?P<job_id>[a-zA-Z0-9_.-]+)/$', views.Job.as_view(),
+        name='job by id'),
     url(r'^add_task', views.AddTask.as_view(), name='add task'),
 ]

--- a/raistlin/tasks/views.py
+++ b/raistlin/tasks/views.py
@@ -47,6 +47,27 @@ class Task(View):
         return JsonResponse(task, safe=False)
 
 
+class Job(View):
+    """Class that manage the queries related to the jobs"""
+
+    http_method_names = ['get']
+
+    def get(self, request, job_id):
+        try:
+            response = requests.get(settings.ARTHUR_SERVER +
+                                    "/job/{}".format(job_id))
+            job = json.loads(response.text)
+        except requests.exceptions.RequestException:
+            err = "Impossible connect to Arthur"
+            return JsonResponse({'status': 'false', 'message': err},
+                                status=500)
+        except json.decoder.JSONDecodeError:
+            err = "Job not found, please check the job ID"
+            return JsonResponse({'status': 'false', 'message': err},
+                                status=500)
+        return JsonResponse(job, safe=False)
+
+
 class AddTask(View):
     http_method_names = ['post']
 

--- a/ui/src/components/Job.vue
+++ b/ui/src/components/Job.vue
@@ -14,7 +14,9 @@
     <div align="left">
       <pre class="logger">
         <code class="log-content">
-          Logs...
+          <p v-if="!job.log">There are not logs for this job yet.</p>
+          <p v-bind:key="log"
+          v-for="log of job.log">{{log.created | prettyDate}} - ({{log.module}}) - {{log.msg}}</p>
         </code>
       </pre>
     </div>
@@ -22,11 +24,29 @@
 </template>
 
 <script>
+import axios from 'axios';
+
 export default {
   name: 'Job',
   data: () => ({
     errors: [],
+    job: {},
   }),
+  created() {
+    this.getJobData(this.$route.params.job_id);
+  },
+  methods: {
+    getJobData(jobId) {
+      axios
+        .get(`/tasks/job_id/${jobId}`)
+        .then((response) => {
+          this.job = response.data;
+        })
+        .catch((e) => {
+          this.errors.push(e.response);
+        });
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
This PR adds the functionality of showing the logs in the UI part querying the server part, so it includes:
- A new URL/endpoint in the server-side
- The corresponding layout of the jobs on the UI side.

Related to #13 

---

In order to test it, follow the next steps:

1. Install dependencies and build the ui app (inside the ui folder)
```bash

raistlin/ui $> yarn install
raistlin/ui $> yarn build

```

2. Python requeriments and launch django server:

```bash
raistlin $> pip3 install -r requeriments.txt
raistlin $> python manage.py migrate --settings=config.settings.devel
raistlin $> python manage.py makemigrations --settings=config.settings.devel
raistlin $> python manage.py runserver --settings=config.settings.devel
```