### PR TITLE
[ui] Refresh Job data on job component

### DIFF
--- a/ui/src/components/Job.vue
+++ b/ui/src/components/Job.vue
@@ -72,9 +72,17 @@ export default {
   data: () => ({
     errors: [],
     job: {},
+    autorefresh: undefined,
   }),
   created() {
     this.getJobData(this.$route.params.job_id);
+
+    if (this.job.job_status !== 'finished' && this.job.job_status !== 'failed') {
+      const self = this;
+      this.autorefresh = setInterval(() => {
+        self.getJobData(self.$route.params.job_id);
+      }, 5000);
+    }
   },
   methods: {
     getJobData(jobId) {


### PR DESCRIPTION
This commit adds the functionality of autorefresh the job data
when the user is in the Job view, this includes both status and
log.


So this PR is valid both #25 and #23 